### PR TITLE
Delete NS_ADDRESS definition from mod_multicast.erl

### DIFF
--- a/mod_multicast/src/mod_multicast.erl
+++ b/mod_multicast/src/mod_multicast.erl
@@ -70,9 +70,6 @@
 -define(VERSION_MULTICAST, "$Revision: 440 $ ").
 -define(PROCNAME, ejabberd_mod_multicast).
 
-%% TODO: move this line to jlib.hrl
--define(NS_ADDRESS, "http://jabber.org/protocol/address").
-
 -define(PURGE_PROCNAME, ejabberd_mod_multicast_purgeloop).
 
 %% TODO: allow configuration instead of hard-coding


### PR DESCRIPTION
While trying to compile mod_multicast I had this error:

~/ejabberd-contrib/mod_multicast$ ./build.sh
Recompile: src/mod_multicast
src/mod_multicast.erl:74: redefining macro 'NS_ADDRESS'

This commit fixes the problem. I think this change should be applied to 2.1.x branch as well.
