### PR TITLE
Fix "muc_online_rooms" output

### DIFF
--- a/mod_muc_admin/src/mod_muc_admin.erl
+++ b/mod_muc_admin/src/mod_muc_admin.erl
@@ -171,9 +171,9 @@ muc_online_rooms(ServerHost) ->
       fun({_, {Roomname, Host}, _}, Results) ->
 	      case MUCHost of
 		  global ->
-		      [Roomname, <<"@">>, Host | Results];
+		      [<<Roomname/binary, "@", Host/binary>> | Results];
 		  Host ->
-		      [Roomname, <<"@">>, Host | Results];
+		      [<<Roomname/binary, "@", Host/binary>> | Results];
 		  _ ->
 		      Results
 	      end


### PR DESCRIPTION
Without this change, `mod_muc_admin` will add newline characters before and after the `@` sign in the `muc_online_rooms` output.
