### PR TITLE
mod_admin_extra: Fix argument types

### DIFF
--- a/mod_admin_extra/src/mod_admin_extra.erl
+++ b/mod_admin_extra/src/mod_admin_extra.erl
@@ -532,12 +532,12 @@ commands() ->
      #ejabberd_commands{name = stats, tags = [stats],
 			desc = "Get statistical value: registeredusers onlineusers onlineusersnode uptimeseconds",
 			module = ?MODULE, function = stats,
-			args = [{name, string}],
+			args = [{name, binary}],
 			result = {stat, integer}},
      #ejabberd_commands{name = stats_host, tags = [stats],
 			desc = "Get statistical value for this host: registeredusers onlineusers",
 			module = ?MODULE, function = stats,
-			args = [{name, string}, {host, string}],
+			args = [{name, binary}, {host, binary}],
 			result = {stat, integer}}
     ].
 


### PR DESCRIPTION
Fix the argument types of mod_admin_extra's `stats` and `stats_host` commands.
