### PR TITLE
Fix "ejabberdctl muc_online_rooms global"

### DIFF
--- a/mod_muc_admin/src/mod_muc_admin.erl
+++ b/mod_muc_admin/src/mod_muc_admin.erl
@@ -877,6 +877,8 @@ find_host(global) ->
     global;
 find_host("global") ->
     global;
+find_host(<<"global">>) ->
+    global;
 find_host(ServerHost) when is_list(ServerHost) ->
     find_host(list_to_binary(ServerHost));
 find_host(ServerHost) ->


### PR DESCRIPTION
Fix the issue that `ejabberdctl muc_online_rooms global` currently doesn't produce any output.
