### PR TITLE
mod_message_log: Stop cleanly

### DIFF
--- a/mod_message_log/src/mod_message_log.erl
+++ b/mod_message_log/src/mod_message_log.erl
@@ -60,7 +60,7 @@ stop(Host) ->
 	  ok;
       _ ->
 	  ejabberd_hooks:delete(reopen_log_hook, ?MODULE, reopen_log, 42),
-	  gen_mod:get_module_proc(Host, ?PROCNAME) ! stop,
+	  ?PROCNAME ! stop,
 	  ok
     end.
 


### PR DESCRIPTION
This commit fixes the following error message when shutting down ejabberd:

    @gen_mod:stop_module_keep_config:126
    {badarg,[{mod_message_log,stop,1,
              [{file,"src/mod_message_log.erl"},{line,64}]},
             {gen_mod,stop_module_keep_config,2,
              [{file,"src/gen_mod.erl"},{line,125}]},...]}

The `mod_message_log` module doesn't use `gen_mod:get_module_proc/2` to generate process names, as only one process (per node) is started for all virtual hosts.