### PR TITLE
Make mod_cron behave more like unix cron

### DIFF
--- a/mod_cron/README.txt
+++ b/mod_cron/README.txt
@@ -31,8 +31,16 @@ Each task is described with five elements:
 * Time is an integer.
 * Units indicates the time unit you use. It can be: seconds, minutes, hours, days.
 * Module and * Function are the exact call you want to schedule.
-* Arguments is an erlang list of arguments inside the characters "> ."
+* Arguments is an array.  Strings will be converted to binaries.
+* timer_type is one of 'fixed' or 'interval'.  Fixed timers occur at a fixed time
+  after the [minute|hour|day] e.g. every hour on the 5th minute (1:05PM, 2:05PM etc)
+  interval timers occur every interval (starting on an even unit) e.g. every 10 minutes
+  starting at 1PM, 1:10PM, 1:20PM etc.  
 
+  Fixed timers are the equivalent of unix cron's comma syntax e.g. "2 * * *" and interval
+  timers are the / syntax e.g. "*/5 * * *".
+
+  Default timer_type is interval.
 
 	EXAMPLE TASKS
 	=============
@@ -45,12 +53,17 @@ modules:
         units: hours
         module: mnesia
         function: info
-        arguments: "> []."
+        arguments: {}
+        timer_type: fixed
       - time: 10
         units: seconds
         module: ejabberd_auth
         function: try_register
-        arguments: "> [\"user1\", \"localhost\", \"somepass\"]."
+        arguments: 
+          - "user1"
+          - "localhost"
+          - "somepass"
+        timer_type: interval
 
 
 	EJABBERD COMMANDS


### PR DESCRIPTION
Support two types of cron: interval and fixed

This updates mod_cron to have much more unix-cron like behavior.  The old
version would start an interval timer whenever ejabberd started, which isn't
a particularly useful starting point (I don't care for my regular activities
to be based on when the server was last booted).

This version allows two types of entries: timers based on an interval,
e.g. every 10 seconds (which would start on the minute, so occur at
00:00s, 00:10s, 00:20s etc) and fixed timers occuring once per
parent-interval.  e.g. a fixed 10s timer would occur at 00:10s,
01:10s etc. (ie its a one minute interval happening 10seconds
after every minute).
