### PR TITLE
fix connected_users_info in mod_admin_extra

### DIFF
--- a/mod_admin_extra/src/mod_admin_extra.erl
+++ b/mod_admin_extra/src/mod_admin_extra.erl
@@ -860,7 +860,11 @@ connected_users_info() ->
 	      NodeS = atom_to_list(node(Pid)),
 	      Uptime = CurrentSec - calendar:datetime_to_gregorian_seconds(
 				      calendar:now_to_local_time(Now)),
-	      {[U, $@, S, $/, R], atom_to_list(Conn), IPS, Port, Priority, NodeS, Uptime}
+	      PriorityI = case Priority of
+			      PI when is_integer(PI) -> PI;
+			      _ -> nil
+			  end,
+	      {[U, $@, S, $/, R], atom_to_list(Conn), IPS, Port, PriorityI, NodeS, Uptime}
       end,
       USRIs).
 


### PR DESCRIPTION
I got p1_xmlrpc process crash when calling connected_users_info xmlrpc request.
This issue was caused by priority of users session is undefined atom.
nil is valid for XMLRPC.
~~~
exception error: {function_clause,[{p1_xmlrpc,encode_param,[undefined],[{file,"src/p1_xmlrpc.erl"},{line,117}]},{p1_xmlrpc,'-encode_param/1-lc$^1/1-0-',1,[{file,"src/p1_xmlrpc.erl"},{line,130}]},{p1_xmlrpc,encode_param,1,[{file,"src/p1_xmlrpc.erl"},{line,130}]},{p1_xmlrpc,'-encode_param/1-lc$^0/1-1-',1,[{file,"src/p1_xmlrpc.erl"},{line,128}]},{p1_xmlrpc,'-encode_param/1-lc$^0/1-1-',1,[{file,"src/p1_xmlrpc.erl"},{line,128}]},{p1_xmlrpc,encode_param,1,[{file,"src/p1_xmlrpc.erl"},{line,128}]},{p1_xmlrpc,'-encode_param/1-lc$^1/1-0-',1,[{file,"src/p1_xmlrpc.erl"},{line,130}]},{p1_xmlrpc,encode_param,1,[{file,"src/p1_xmlrpc.erl"},{line,130}]}]}
~~~