### PR TITLE
mod_statsdx: Recognize two polish client names

### DIFF
--- a/mod_statsdx/src/mod_statsdx.erl
+++ b/mod_statsdx/src/mod_statsdx.erl
@@ -877,6 +877,8 @@ list_elem(clients, full) ->
      {"Profanity", profanity},
      {"centerim", centerim},
      {"Conversations", conversations},
+     {"AQQ", aqq},
+     {"WTW", wtw},
      {"yaxim", yaxim},
      {"unknown", unknown}
     ];


### PR DESCRIPTION
Recognize two polish client names in mod_statsdx.