### PR TITLE
mod_admin_extra: Let send_message omit subject

### DIFF
--- a/mod_admin_extra/src/mod_admin_extra.erl
+++ b/mod_admin_extra/src/mod_admin_extra.erl
@@ -1406,10 +1406,9 @@ send_packet_all_resources(FromJID, ToU, ToS, ToR, Packet) ->
     ejabberd_router:route(FromJID, ToJID, Packet).
 
 build_packet(Type, Subject, Body) ->
-    Tail = case Subject of
-	<<"chat">> -> [];
-	_ -> [{xmlel, <<"subject">>, [], [{xmlcdata, Subject}]}]
-    end,
+    Tail = if Subject == <<"">>; Type == <<"chat">> -> [];
+	      true -> [{xmlel, <<"subject">>, [], [{xmlcdata, Subject}]}]
+	   end,
     {xmlel, <<"message">>,
      [{<<"type">>, Type}, {<<"id">>, randoms:get_string()}],
      [{xmlel, <<"body">>, [], [{xmlcdata, Body}]} | Tail]


### PR DESCRIPTION
The `send_message` command currently always adds a `<subject/>` to the message, _except_ when the user specified the string "chat" as the subject.  I guess the idea was to omit the subject if the user specified "chat" as the _message type_.  So this commit does that, and it also lets `send_message` omit the subject if the user specified an empty subject.