### PR TITLE
Update modules to work with ejabberd 15.06

### DIFF
--- a/mod_log_chat/src/mod_log_chat.erl
+++ b/mod_log_chat/src/mod_log_chat.erl
@@ -13,8 +13,8 @@
 -export([start/2,
          init/1,
 	 stop/1,
-	 log_packet_send/3,
-	 log_packet_receive/4]).
+	 log_packet_send/4,
+	 log_packet_receive/5]).
 
 -ifndef(LAGER).
 -define(LAGER, 1).
@@ -77,13 +77,15 @@ stop(Host) ->
     gen_mod:get_module_proc(Host, ?PROCNAME) ! stop,
     ok.
 
-log_packet_send(From, To, Packet) ->
-    log_packet(From, To, Packet, From#jid.lserver).
+log_packet_send(Packet, _C2SState, From, To) ->
+    log_packet(From, To, Packet, From#jid.lserver),
+    Packet.
 
-log_packet_receive(_JID, From, To, _Packet) when From#jid.lserver == To#jid.lserver->
-    ok; % only log at send time if the message is local to the server
-log_packet_receive(_JID, From, To, Packet) ->
-    log_packet(From, To, Packet, To#jid.lserver).
+log_packet_receive(Packet, _C2SState, _JID, From, To) when From#jid.lserver == To#jid.lserver->
+    Packet; % only log at send time if the message is local to the server
+log_packet_receive(Packet, _C2SState, _JID, From, To) ->
+    log_packet(From, To, Packet, To#jid.lserver),
+    Packet.
 
 log_packet(From, To, Packet = #xmlel{name = <<"message">>, attrs = Attrs}, Host) ->
     case xml:get_attr_s(<<"type">>, Attrs) of

--- a/mod_logxml/src/mod_logxml.erl
+++ b/mod_logxml/src/mod_logxml.erl
@@ -12,7 +12,7 @@
 -behaviour(gen_mod).
 
 -export([start/2, init/7, stop/1,
-	 send_packet/3, receive_packet/4]).
+	 send_packet/4, receive_packet/5]).
 
 -include("ejabberd.hrl").
 -include("jlib.hrl").
@@ -166,15 +166,17 @@ loop(Host, IoDevice, Filename, Logdir, CheckRKP, RotateO, PacketC,
 		 Gregorian_day, Timezone, ShowIP, FilterO)
     end.
 
-send_packet(FromJID, ToJID, P) ->
+send_packet(P, _C2SState, FromJID, ToJID) ->
     Host = FromJID#jid.lserver,
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
-    Proc ! {addlog, {send, FromJID, ToJID, P}}.
+    Proc ! {addlog, {send, FromJID, ToJID, P}},
+    P.
 
-receive_packet(_JID, From, To, P) ->
+receive_packet(P, _C2SState, _JID, From, To) ->
     Host = To#jid.lserver,
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
-    Proc ! {addlog, {recv, From, To, P}}.
+    Proc ! {addlog, {recv, From, To, P}},
+    P.
 
 add_log(Io, Timezone, ShowIP, {Orientation, From, To, Packet}, _OSD) ->
     %%{Orientation, Stanza, Direction} = OSD, 

--- a/mod_message_log/src/mod_message_log.erl
+++ b/mod_message_log/src/mod_message_log.erl
@@ -25,8 +25,8 @@
 	 code_change/3]).
 
 %% ejabberd_hooks callbacks.
--export([log_packet_send/3,
-	 log_packet_receive/4,
+-export([log_packet_send/4,
+	 log_packet_receive/5,
 	 log_packet_offline/3,
 	 reopen_log/0]).
 
@@ -140,15 +140,17 @@ code_change(_OldVsn, State, _Extra) ->
 %% ejabberd_hooks callbacks.
 %% -------------------------------------------------------------------
 
--spec log_packet_send(jid(), jid(), xmlel()) -> any().
+-spec log_packet_send(xmlel(), term(), jid(), jid()) -> xmlel().
 
-log_packet_send(From, To, Packet) ->
-    log_packet(outgoing, From, To, Packet).
+log_packet_send(Packet, _C2SState, From, To) ->
+    log_packet(outgoing, From, To, Packet),
+    Packet.
 
--spec log_packet_receive(jid(), jid(), jid(), xmlel()) -> any().
+-spec log_packet_receive(xmlel(), term(), jid(), jid(), jid()) -> xmlel().
 
-log_packet_receive(JID, From, _To, Packet) ->
-    log_packet(incoming, From, JID, Packet).
+log_packet_receive(Packet, _C2SState, JID, From, _To) ->
+    log_packet(incoming, From, JID, Packet),
+    Packet.
 
 -spec log_packet_offline(jid(), jid(), xmlel()) -> any().
 

--- a/mod_post_log/src/mod_post_log.erl
+++ b/mod_post_log/src/mod_post_log.erl
@@ -14,7 +14,7 @@
 
 -export([start/2,
          stop/1,
-         log_user_send/3,
+         log_user_send/4,
          post_result/1]).
 
 -include("ejabberd.hrl").
@@ -36,8 +36,9 @@ stop(Host) ->
                           ?MODULE, log_user_send, 50),
     ok.
 
-log_user_send(From, To, Packet) ->
-    ok = log_packet(From, To, Packet).
+log_user_send(Packet, _C2SState, From, To) ->
+    ok = log_packet(From, To, Packet),
+    Packet.
 
 log_packet(From, To, #xmlel{name = <<"message">>} = Packet) ->
     ok = log_message(From, To, Packet);


### PR DESCRIPTION
The `user_send_packet` and `user_receive_packet` hooks were [changed in ejabberd 15.06][1].  Update the modules accordingly.

[1]: https://github.com/processone/ejabberd/commit/83cce468a573d3ca58a0c6653a2ccc17c7b4dbc3