### PR TITLE
Support the use of a separate download host in mod_s3_upload

### DIFF
--- a/mod_s3_upload/conf/mod_s3_upload.yml
+++ b/mod_s3_upload/conf/mod_s3_upload.yml
@@ -2,6 +2,8 @@ modules:
   mod_s3_upload:
     region: us-west-1
     bucket_url: https://example.s3.us-west-1.wasabisys.com
+    ## Set this if you wish to use a different base URL for downloads
+    # download_url: https://my-super-cdn.com
     access_key_id: WBPXK3YWS457RV9P
     access_key_secret: N2UC4RSLPU6VH6FYGNJ9BRNMC74XM6G9MP74RNH7D4ZG9UBZY9Z5G4ZR8T782KR7
     ## Maximum permitted object size, in bytes


### PR DESCRIPTION
In response to #319, this PR adds the ability to configure `mod_s3_upload` such that the GET URL may point somewhere other than the bucket, e.g. a WAF, CDN, or load balancer.