### PR TITLE
fix mod_s3_upload

### DIFF
--- a/mod_s3_upload/src/mod_s3_upload.erl
+++ b/mod_s3_upload/src/mod_s3_upload.erl
@@ -474,6 +474,9 @@ object_url(BucketURL, ObjectName) ->
           ObjectName :: binary().
 % generate reasonably unique sortable (by time first) object name.
 object_name(Filename) ->
-    str:format("~.36B~.36B-~s", [os:system_time(microsecond),
-                                 erlang:phash2(node()),
-                                 uri_string:quote(Filename)]).
+    <<RandomPrefix:128/big-unsigned-integer>> = crypto:strong_rand_bytes(16),
+    RandomPrefixS = str:format("~32.16.0b", [RandomPrefix]),
+    FolderName = str:substr(RandomPrefixS, 1, 2),
+    str:format("~s/~s-~s", [FolderName,
+                            RandomPrefixS,
+                            uri_string:quote(Filename)]).

--- a/mod_s3_upload/src/mod_s3_upload.erl
+++ b/mod_s3_upload/src/mod_s3_upload.erl
@@ -51,6 +51,8 @@
 
 -import(gen_mod, [get_opt/2]).
 
+-import(crypto, [strong_rand_bytes/1]).
+
 %%-----------------------------------------------------------------------
 %% gen_mod callbacks and related machinery
 %%-----------------------------------------------------------------------
@@ -474,4 +476,4 @@ object_url(BucketURL, ObjectName) ->
 object_name(Filename) ->
     str:format("~.36B~.36B-~s", [os:system_time(microsecond),
                                  erlang:phash2(node()),
-                                 Filename]).
+                                 uri_string:quote(Filename)]).


### PR DESCRIPTION
A recent update to mod_s3_upload caused it to start crashing with a stack trace similar to below:
```
registered_name: 'mod_s3_upload_[redacted]'
exception error: no match of right hand side value
                 #{path => <<"GMCN2Q0FY3WVXX0-Identicon.png">>,
                   query =>
                       <<"Content-Type=image%2Fpng&Content-Length=539&X-Amz-Acl=public-read">>}
  in function  aws_util:signed_url/7 (/opt/ejabberd/.ejabberd-modules/sources/ejabberd-contrib/mod_s3_upload/src/aws_util.erl, line 62)
  in call from mod_s3_upload:put_get_url/3 (/opt/ejabberd/.ejabberd-modules/sources/ejabberd-contrib/mod_s3_upload/src/mod_s3_upload.erl, line 414)
  in call from mod_s3_upload:handle_iq/2 (/opt/ejabberd/.ejabberd-modules/sources/ejabberd-contrib/mod_s3_upload/src/mod_s3_upload.erl, line 343)
  in call from mod_s3_upload:handle_info/2 (/opt/ejabberd/.ejabberd-modules/sources/ejabberd-contrib/mod_s3_upload/src/mod_s3_upload.erl, line 224)
  in call from gen_server:try_dispatch/4 (gen_server.erl, line 1123)
  in call from gen_server:handle_msg/6 (gen_server.erl, line 1200)
```

This PR fixes that. It also includes a couple of security-related patches that prevent escape from the S3 bucket, and make enumeration significantly more difficult.