### PR TITLE
mod_captcha_rust: fix typo in README.md

### DIFF
--- a/mod_captcha_rust/README.md
+++ b/mod_captcha_rust/README.md
@@ -33,7 +33,7 @@ ejabberd source code and apply this small patch:
  
    defp deps do
      [{:base64url, "~> 1.0"},
-+     {:captcha_nif, "~> 0.1", hex: :captcha_nif},
++     {:captcha, "~> 0.1", hex: :captcha_nif},
       {:cache_tab, "~> 1.0"},
       {:eimp, "~> 1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},


### PR DESCRIPTION
During compilation `:captcha` is the name of the application to be installed, not `:captcha_nif`, which leads to a failure.

The [source repo](https://github.com/feng19/captcha) also uses:

```erl
def deps do
  [
    {:captcha, "~> 0.1", hex: :captcha_nif}
  ]
end
```