### PR TITLE
mod_prometheus: use 'declare' rather than 'new' for histogram and counter  (#339)

### DIFF
--- a/mod_prometheus/example/docker-compose.yml
+++ b/mod_prometheus/example/docker-compose.yml
@@ -3,17 +3,25 @@ version: '3.7'
 services:
 
   prometheus:
-    network_mode: "host"
     image: docker.io/prom/prometheus
     container_name: prometheus
     ports:
       - "9090:9090"
     volumes:
+      - prometheus-data:/prometheus
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    restart: always
 
   grafana:
-    network_mode: "host"
     image: docker.io/grafana/grafana-enterprise
     container_name: grafana
     ports:
       - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana_defaults.ini:/usr/share/grafana/conf/defaults.ini
+    restart: always
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/mod_prometheus/src/mod_prometheus.erl
+++ b/mod_prometheus/src/mod_prometheus.erl
@@ -352,7 +352,7 @@ handle_histogram(Name, HName, HistogramOpts, Host, Action, State) ->
   InitArg = State#{name => HName, labels => LabelNames},
   case Action of
     subscribe ->
-      prometheus_histogram:new(
+      prometheus_histogram:declare(
         [
           {name, HName},
           {buckets, maps:get(buckets, HistogramOpts, [1, 10, 100, 500, 750, 1000, 3000, 5000])},
@@ -377,7 +377,7 @@ handle_counter(Name, HName, CounterOpts, Host, Action, State) ->
   InitArg = State#{name => HName, labels => LabelNames},
   case Action of
     subscribe ->
-      prometheus_counter:new(
+      prometheus_counter:declare(
         [{name, HName}, {help, maps:get(help, CounterOpts, "No help")}, {labels, LabelNames}]
       ),
       ?INFO_MSG("Created new Prometheus counter for ~p with labels ~p", [HName, LabelNames]),


### PR DESCRIPTION
If a node crashes metrics might already be defined in prometheus and thus 'new' would crash.

Fixes #339 