### PR TITLE
mod_spam_filter: handle rtbl blocked domains

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.erl]
+indent_style = tab
+indent_size = 4
+tab_width = 8

--- a/mod_spam_filter/README.md
+++ b/mod_spam_filter/README.md
@@ -2,17 +2,17 @@ mod_spam_filter - Filter spam messages based on JID/content
 ===========================================================
 
 * Author: Holger Weiss <holger@zedat.fu-berlin.de>
-
+* Author: Stefan Strigler <stefan@strigler.de>
 
 Description
 -----------
 
 This module allows for filtering spam messages and subscription requests
-received from remote servers based on lists of known spammer JIDs and/or
-URLs mentioned in spam messages.  Traffic classified as spam is rejected
-with an error (and an `[info]` message is logged) unless the sender is
-subscribed to the recipient's presence.  An access rule can be specified
-to control which recipients are subject to spam filtering.
+received from remote servers based on RTBL domain lists, lists of known spammer
+JIDs and/or URLs mentioned in spam messages. Traffic classified as spam is
+rejected with an error (and an `[info]` message is logged) unless the sender is
+subscribed to the recipient's presence. An access rule can be specified to
+control which recipients are subject to spam filtering.
 
 
 Configuration
@@ -23,12 +23,23 @@ To enable this module, configure it like this:
 ```yaml
 modules:
   mod_spam_filter:
+    rtbl_host: "xmppbl.org"
     spam_jids_file: "/etc/ejabberd/spam-filter/jids.txt"
     spam_urls_file: "/etc/ejabberd/spam-filter/urls.txt"
 ```
 
 The configurable `mod_spam_filter` options are:
 
+- `rtbl_host` (default: none)
+
+  This option specifies which RTBL host to use to query for blocked domains. One
+  such host is located at `xmppbl.org`. Messages and presence-subscribe stanzas
+  originating from domains listed at this host will be blocked in case there is
+  no active roster subscription of the recipeient. If a dump file is configured,
+  messages will get logged. Senders will receive an abuse notification message.
+  The command `ejabberdctl get_blocked_domains` retrieves the current list of
+  blocked domains.
+  
 - `spam_dump_file` (default: `none`)
 
   This option specifies the path to a file that messages classified as
@@ -79,12 +90,20 @@ ejabberd Commands
 -----------------
 
 This module provides ejabberdctl/API calls to reread the spam JID/URL
-files, to print the JID cache contents, and to remove entries from that
-cache.  See:
+files, to print the JID cache contents, and to add or remove entries from that
+cache.  
+
+Furthermore you can add and query the list of blocked domains as retrieved from
+the RTBL host.
+
+See:
 
 ```
-$ ejabberdctl help reload-spam-filter-files
-$ ejabberdctl help get-spam-filter-cache
-$ ejabberdctl help expire-spam-filter-cache
+$ ejabberdctl help add_blocked_domain
+$ ejabberdctl help add_to_spam_filter_cache
 $ ejabberdctl help drop-from-spam-filter-cache
+$ ejabberdctl help expire-spam-filter-cache
+$ ejabberdctl help get-spam-filter-cache
+$ ejabberdctl help get_blocked_domains
+$ ejabberdctl help reload-spam-filter-files
 ```

--- a/mod_spam_filter/TODO.org
+++ b/mod_spam_filter/TODO.org
@@ -1,0 +1,30 @@
+#+title: TODO / Improvements / Wishlist for mod_spam_filter
+#+author: Stefan Strigler (zeank@jwchat.org)
+#+date: 2025-04-02
+#+synopsis: Collection of todos, ideas, wishlist, comments. Feel free to contribute, any feedback appreciated.
+
+* TODOS [0/7]
+** TODO Allow to configure node-name
+** TODO Filter telegram channels (etc) via file
+** TODO Filter domains via file
+** TODO Whitelist for filtered domains
+** TODO Filter list of greetings (via file) [maybe]
+** TODO Check if sending jid is from muc/mix service (maybe in bookmarks?)
+** TODO Parse meta-info given on RTBL blocked domains
+*** default policy, eg `block-strangers` (basically hardcoded for now)
+** TODO [0/3] Pubsub XEP bug? Publish node and retract node can only have one item? Needs clarification. Schema says otherwise. 
+    - [ ] Ask Mailinglist
+    - [ ] Bug report on p1/xmpp -> doesn‘t handle multiple items correctly
+    - [ ] Evtl bug in ejabberd mod_pubsub
+** TODO Forward Reports (is this the right place?). See [[https://pad.nixnet.services/s/1ZrHSLq0G][Simplified XMPP Incident Exchange]]
+
+* Ideas/Wishlist
+** Allow list of RTBL hosts
+*** Config option for multiple hosts and their node-names respectivly (and maybe default policy)
+*** Query list of RTBL hosts
+*** Merge strategy for multiple results, block policies (if more than one host), eg
+   - one
+   - more_than_one
+   - all
+** Scoring system (eg: is spam domain? has url(s)? suspicious jid? suspicious host (ibr active)? etc ...)
+** 

--- a/mod_spam_filter/src/mod_spam_filter_rtbl.erl
+++ b/mod_spam_filter/src/mod_spam_filter_rtbl.erl
@@ -1,0 +1,105 @@
+-module(mod_spam_filter_rtbl).
+
+-include_lib("xmpp/include/xmpp.hrl").
+-include("logger.hrl").
+
+-define(RTBL_DOMAINS_NODE, <<"spam_source_domains">>).
+-define(SERVICE_JID_PREFIX, "rtbl-").
+
+-export([parse_blocked_domains/1,
+	 parse_pubsub_event/1,
+	 pubsub_event_handler/1,
+	 request_blocked_domains/2,
+	 subscribe/2,
+	 unsubscribe/2]).
+
+subscribe(RTBLHost, From) ->
+    FromJID = service_jid(From),
+    SubIQ = #iq{type = set, to = jid:make(RTBLHost), from = FromJID,
+		sub_els = [
+			   #pubsub{subscribe = #ps_subscribe{jid = FromJID, node = ?RTBL_DOMAINS_NODE}}]},
+    ?DEBUG("Sending subscription request:~n~p", [xmpp:encode(SubIQ)]),
+    ejabberd_router:route_iq(SubIQ, subscribe_result, self()).
+
+unsubscribe(undefined, _From) ->
+    ok;
+unsubscribe(RTBLHost, From) ->
+    FromJID = jid:make(From),
+    SubIQ = #iq{type = set, to = jid:make(RTBLHost), from = FromJID,
+		sub_els = [
+			   #pubsub{unsubscribe = #ps_unsubscribe{jid = FromJID, node = ?RTBL_DOMAINS_NODE}}]},
+    ejabberd_router:route_iq(SubIQ, unsubscribe_result, self()).
+
+-spec request_blocked_domains(binary(), binary()) -> ok.
+request_blocked_domains(undefined, _From) ->
+    ok;
+request_blocked_domains(RTBLHost, From) ->
+    IQ = #iq{type = get, from = jid:make(From),
+	     to = jid:make(RTBLHost),
+	     sub_els = [
+			#pubsub{items = #ps_items{node = ?RTBL_DOMAINS_NODE}}]},
+    ?DEBUG("Requesting RTBL blocked domains from ~s:~n~p", [RTBLHost, xmpp:encode(IQ)]),
+    ejabberd_router:route_iq(IQ, blocked_domains, self()).
+
+-spec parse_blocked_domains(stanza()) -> #{binary() => any()} | undefined.
+parse_blocked_domains(#iq{from = From, type = result} = IQ) ->
+    ?DEBUG("parsing fetched items from ~p", [From]),
+    case xmpp:get_subtag(IQ, #pubsub{}) of
+	#pubsub{items = #ps_items{node = ?RTBL_DOMAINS_NODE, items = Items}} ->
+	    ?DEBUG("Got items:~n~p", [Items]),
+	    parse_items(Items);
+	_ ->
+	    undefined
+    end.
+
+-spec parse_pubsub_event(stanza()) -> #{binary() => any()}.
+parse_pubsub_event(Msg) ->
+    case xmpp:get_subtag(Msg, #ps_event{}) of
+	#ps_event{items = #ps_items{node = ?RTBL_DOMAINS_NODE, retract = ID}} when ID /= undefined ->
+	    ?DEBUG("Got item to retract:~n~p", [ID]),
+	    #{ID => false};
+	#ps_event{items = #ps_items{node = ?RTBL_DOMAINS_NODE, items = Items}} ->
+	    ?DEBUG("Got items:~n~p", [Items]),
+	    parse_items(Items);
+	Other ->
+	    ?WARNING_MSG("Couldn't extract items: ~p", [Other]),
+	    #{}
+    end.
+
+-spec parse_items([ps_item()]) -> #{binary() => any()}.
+parse_items(Items) ->
+    lists:foldl(
+      fun(#ps_item{id = ID}, Acc) ->
+	      %% TODO extract meta/extra instructions
+	      maps:put(ID, true, Acc)
+      end, #{}, Items).
+
+-spec service_jid(binary()) -> jid().
+service_jid(Host) ->
+    jid:make(<<>>, Host, <<?SERVICE_JID_PREFIX, (ejabberd_cluster:node_id())/binary>>).
+
+%%--------------------------------------------------------------------
+%% Hook callbacks.
+%%--------------------------------------------------------------------
+
+-spec pubsub_event_handler(stanza()) -> drop | stanza().
+pubsub_event_handler(#message{from = FromJid,
+			      to = #jid{lserver = LServer,
+					lresource = <<?SERVICE_JID_PREFIX, _/binary>>}} = Msg) ->
+
+    ?DEBUG("Got RTBL message to:~n~p", [Msg]),
+    From = jid:encode(FromJid),
+    case gen_mod:get_module_opt(LServer, mod_spam_filter, rtbl_host) of
+	From ->
+	    ParsedItems = parse_pubsub_event(Msg),
+	    Proc = gen_mod:get_module_proc(LServer, mod_spam_filter),
+	    gen_server:cast(Proc, {update_blocked_domains, ParsedItems}),
+	    %% FIXME what's the difference between `{drop, ...}` and `{stop, {drop, ...}}`?
+	    drop;
+	_Other ->
+	    ?INFO_MSG("Got unexpected message from ~s to rtbl resource:~n~p", [From, Msg]),
+	    Msg
+    end;
+pubsub_event_handler(Acc) ->
+    ?DEBUG("unexpected something on pubsub_event_handler: ~p", [Acc]),
+    Acc.


### PR DESCRIPTION
This adds support for RTBL blocked domains similar to how prosody's `mod_anti_spam` does it, following the guide at https://xmppbl.org/dev. It subscribes to the `spam_source_domains` pubsub node at the given `rtbl_host` (eg. use "xmppbl.org") and retrieves a list of domains. Presence and message stanzas from there are treated like `block-strangers`, means only if there's a roster subscription they are being let through.

I've add the following commands:

- get_blocked_domains
- add_blocked_domain
- add_to_spam_filter_cache