### PR TITLE
added default config for mod_autoreload

### DIFF
--- a/mod_autoreload/conf/mod_autoreload.yml
+++ b/mod_autoreload/conf/mod_autoreload.yml
@@ -1,4 +1,4 @@
 modules:
   mod_autoreload:
     watch_ssl: true
-    watch_config: true
+    watch_config: false

--- a/mod_autoreload/conf/mod_autoreload.yml
+++ b/mod_autoreload/conf/mod_autoreload.yml
@@ -1,0 +1,4 @@
+modules:
+  mod_autoreload:
+    watch_ssl: true
+    watch_config: true


### PR DESCRIPTION
As requested by @badlop in pull request: https://github.com/processone/ejabberd-contrib/pull/368#issuecomment-3582347842

Added the conf/mod_autoreload.yml 

This will autoload the module with default values after it is installed.

Did already created that file but forgot to commit  